### PR TITLE
Add `reduce_reducible_to cases/4` cases to handle `:other`

### DIFF
--- a/lib/credo_unneccesary_reduce/check.ex
+++ b/lib/credo_unneccesary_reduce/check.ex
@@ -1,7 +1,7 @@
 defmodule CredoUnnecessaryReduce.Check do
   @moduledoc """
-  This Credo check identifies instances where `Enum.reduce` can be 
-  replaced with more idiomatic and efficient functions, such as 
+  This Credo check identifies instances where `Enum.reduce` can be
+  replaced with more idiomatic and efficient functions, such as
   `Enum.filter`, `Enum.map`, `Enum.any?`, and `Map.new`.
 
   """
@@ -183,6 +183,8 @@ defmodule CredoUnnecessaryReduce.Check do
         {:acc_var, :integer, :addition} -> "Enum.count"
         {:acc_var, _, :mult} -> "Enum.product_by"
         {:acc_var, _, :addition} -> "Enum.sum_by"
+        {:other, _, _} -> nil
+        {_, :other, _} -> nil
       end
     end
   end


### PR DESCRIPTION
I ran into some issues on a larger code base with errors like:

```
** (CaseClauseError) no case clause matching:

    {:integer, :other, :addition}

    (credo_unnecessary_reduce 0.3.0) lib/credo_unneccesary_reduce/check.ex:176: CredoUnnecessaryReduce.Check.reduce_reducible_to/4
    (credo_unnecessary_reduce 0.3.0) lib/credo_unneccesary_reduce/check.ex:56: CredoUnnecessaryReduce.Check.traverse/3
    (elixir 1.19.5) lib/macro.ex:663: anonymous fn/4 in Macro.do_traverse_args/4
    (stdlib 6.2.2.3) lists.erl:2343: :lists.mapfoldl_1/3
    (stdlib 6.2.2.3) lists.erl:2344: :lists.mapfoldl_1/3
    (elixir 1.19.5) lib/macro.ex:628: Macro.do_traverse/4
    (stdlib 6.2.2.3) lists.erl:2343: :lists.mapfoldl_1/3
    (stdlib 6.2.2.3) lists.erl:2344: :lists.mapfoldl_1/3
```

```
** (CaseClauseError) no case clause matching:

    {:other, :other, :addition}

    (credo_unnecessary_reduce 0.3.0) lib/credo_unneccesary_reduce/check.ex:176: CredoUnnecessaryReduce.Check.reduce_reducible_to/4
    (credo_unnecessary_reduce 0.3.0) lib/credo_unneccesary_reduce/check.ex:56: CredoUnnecessaryReduce.Check.traverse/3
    (elixir 1.19.5) lib/macro.ex:663: anonymous fn/4 in Macro.do_traverse_args/4
    (stdlib 6.2.2.3) lists.erl:2343: :lists.mapfoldl_1/3
    (stdlib 6.2.2.3) lists.erl:2344: :lists.mapfoldl_1/3
    (elixir 1.19.5) lib/macro.ex:628: Macro.do_traverse/4
    (stdlib 6.2.2.3) lists.erl:2343: :lists.mapfoldl_1/3
    (stdlib 6.2.2.3) lists.erl:2344: :lists.mapfoldl_1/3
```

So I added some `case` clauses to handle `:other`.